### PR TITLE
Fixed Quat.from_euler() and package imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,0 @@
-from .common import *
-from .quaternion import Quaternion as Quat
-from .transform import Transform as Xform
-import numpy as np

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+from .common import *
+from .quaternion import Quaternion as Quat
+from .transform import Transform as Xform
+import numpy as np

--- a/quaternion.py
+++ b/quaternion.py
@@ -1,4 +1,4 @@
-from common import *
+from .common import *
 
 
 __qmat_matrix__ = np.array([[[1.0, 0, 0, 0],

--- a/quaternion.py
+++ b/quaternion.py
@@ -1,4 +1,4 @@
-from pytransform.common import *
+from .common import *
 
 
 __qmat_matrix__ = np.array([[[1.0, 0, 0, 0],

--- a/quaternion.py
+++ b/quaternion.py
@@ -1,4 +1,4 @@
-from .common import *
+from common import *
 
 
 __qmat_matrix__ = np.array([[[1.0, 0, 0, 0],
@@ -341,6 +341,11 @@ if __name__ == '__main__':
         assert norm(qR.rota(v) - R.T.dot(v)) < 1e-8
 
         assert norm((q * q.inverse).elements - np.array([[1., 0, 0, 0]]).T) < 1e-8
+
+        # Check from_euler
+        euler = q.euler
+        q_euler = Quaternion.from_euler(*euler.flatten())
+        assert norm(q - q_euler) < 1e-8
 
         # Check that qexp is right by comparing with rotation matrix qexp and axis-angle
         import scipy.linalg

--- a/quaternion.py
+++ b/quaternion.py
@@ -1,4 +1,4 @@
-from common import *
+from pytransform.common import *
 
 
 __qmat_matrix__ = np.array([[[1.0, 0, 0, 0],
@@ -258,10 +258,10 @@ class Quaternion():
         st = np.sin(pitch / 2.0)
         ss = np.sin(yaw / 2.0)
 
-        return Quaternion(np.array([[cp * ct * cs - sp * st * ss],
-                                    [sp * st * cs + cp * ct * ss],
-                                    [sp * ct * cs + cp * st * ss],
-                                    [cp * st * cs - sp * ct * ss]]))
+        return Quaternion(np.array([[cp * ct * cs + sp * st * ss],
+                                    [sp * ct * cs - cp * st * ss],
+                                    [cp * st * cs + sp * ct * ss],
+                                    [cp * ct * ss - sp * st * cs]]))
 
     def otimes(self, q):
         q_new = Quaternion(__qmat_matrix__.dot(q.arr).squeeze().dot(self.arr).copy())

--- a/quaternion.py
+++ b/quaternion.py
@@ -1,4 +1,5 @@
-from .common import *
+import numpy as np
+from .common import skew, norm
 
 
 __qmat_matrix__ = np.array([[[1.0, 0, 0, 0],

--- a/transform.py
+++ b/transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from .quaternion import *
-from .common import *
+from quaternion import *
+from common import *
 
 I_3x3 = np.eye(3)
 

--- a/transform.py
+++ b/transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from .quaternion import *
-from .common import *
+from .quaternion import Quaternion
+from .common import skew, norm
 
 I_3x3 = np.eye(3)
 

--- a/transform.py
+++ b/transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from pytransform.quaternion import *
-from pytransform.common import *
+from .quaternion import *
+from .common import *
 
 I_3x3 = np.eye(3)
 

--- a/transform.py
+++ b/transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from quaternion import *
-from common import *
+from pytransform.quaternion import *
+from pytransform.common import *
 
 I_3x3 = np.eye(3)
 

--- a/transform.py
+++ b/transform.py
@@ -1,6 +1,6 @@
 import numpy as np
-from quaternion import *
-from common import *
+from .quaternion import *
+from .common import *
 
 I_3x3 = np.eye(3)
 


### PR DESCRIPTION
The Quat.from_euler() function had some typos that were fixed. Also, some changes were made to the imports to fix importing errors as well as to allow wild imports for the pytransform package. Now the package can be imported with `from pytransform import *` and the API will look just like the C++ geometry library (Quat, Xform, etc.).